### PR TITLE
Add -cookie flag for sessions behind Cloudflare challenge

### DIFF
--- a/cmd/kneejerk/main.go
+++ b/cmd/kneejerk/main.go
@@ -35,6 +35,10 @@ const defaultUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KH
 
 var userAgent = defaultUserAgent
 
+// Optional Cookie header value, e.g. a cf_clearance grabbed from a real browser
+// after solving a Cloudflare challenge.
+var cookieHeader string
+
 // Pattern for JS bundle files. Anchored at the end and allowing a query string,
 // matches both classic .js and ES-module .mjs extensions.
 var jsFilePattern = regexp.MustCompile(`\.m?js(?:\?.*)?$`)
@@ -152,6 +156,9 @@ func fetchBody(targetURL string) ([]byte, error) {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
+	if cookieHeader != "" {
+		req.Header.Set("Cookie", cookieHeader)
+	}
 
 	res, err := httpClient.Do(req)
 	if err != nil {
@@ -251,12 +258,14 @@ func main() {
 	debug := flag.Bool("debug", false, "Print debugging statements")
 	insecure := flag.Bool("k", false, "Skip TLS certificate verification (insecure)")
 	ua := flag.String("ua", defaultUserAgent, "User-Agent header to send")
+	cookie := flag.String("cookie", "", "Cookie header value to send (e.g. cf_clearance=... from a browser session)")
 	flag.Parse()
 
 	if *insecure {
 		httpClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	}
 	userAgent = *ua
+	cookieHeader = *cookie
 
 	if *output != "" {
 		file, err := os.Create(*output)


### PR DESCRIPTION
## Summary
- Add a `-cookie` flag that passes its value verbatim as the `Cookie` request header on every fetch.
- Lets users replay a `cf_clearance` cookie (or any other session cookie) that was issued to a real browser, so kneejerk can reach targets sitting behind Cloudflare's managed challenge.

## Why
Default Go-http-client got 403'd on https://rumilabs.io with `cf-mitigated: challenge`. Even a full Chrome User-Agent + the headers Chrome sends still got 403 — Cloudflare fingerprints at the TLS / HTTP-2 layer. The pragmatic workaround is to solve the challenge once in a real browser and replay the cf_clearance cookie. This flag is the minimal-architecture path; uTLS or chromedp would solve the underlying fingerprint mismatch but add a much heavier dependency.

## Usage
```
kneejerk -u https://target.example -cookie "cf_clearance=...; other=..."
```
Accepts the entire Cookie header value as a single string, matching how `curl --cookie` works.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Verified end-to-end against a real Cloudflare-protected target (https://rumilabs.io): without `-cookie`, kneejerk hits 403; with the cookie, gets a 200 and the homepage HTML
- [ ] Optional: confirm graceful behavior when an expired cookie is passed (should fall through to the existing 403 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)