### PR TITLE
Add NEXT_PUBLIC, VITE, EXPO_PUBLIC to env-var detection

### DIFF
--- a/cmd/kneejerk/main.go
+++ b/cmd/kneejerk/main.go
@@ -65,8 +65,11 @@ var outputFileWriter *bufio.Writer = nil
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// Regex to find environment variables directly assigned
-var directEnvVarPattern = regexp.MustCompile(`\b(?:NODE|REACT_APP|AWS)_?[A-Z_]*\b\s*:\s*".*?"`)
+// Regex to find environment variables directly assigned. Covers the standard
+// build-time prefixes for the major JS frameworks: Node, CRA (REACT_APP_),
+// Next.js (NEXT_PUBLIC_), Vite (VITE_), Expo (EXPO_PUBLIC_), plus AWS-prefixed
+// vars that frequently leak into bundles.
+var directEnvVarPattern = regexp.MustCompile(`\b(?:NODE|REACT_APP|NEXT_PUBLIC|EXPO_PUBLIC|VITE|AWS)_?[A-Z_]*\b\s*:\s*".*?"`)
 
 func scrapeEnvVars(jsURL string, jsContent string) {
 	// First, check for direct assignments


### PR DESCRIPTION
## Summary
Extend \`directEnvVarPattern\` to recognize the build-time env-var prefixes used by:
- Next.js (\`NEXT_PUBLIC_*\`)
- Vite (\`VITE_*\`)
- Expo (\`EXPO_PUBLIC_*\`)

alongside the existing \`NODE_*\`, \`REACT_APP_*\`, \`AWS_*\` coverage.

## Why
Half the modern web isn't CRA. Without these prefixes, scanning a Next.js or Vite app silently skips the very env vars the tool exists to find — even when the bundle preserves them in an object-literal shape that the regex can match.

## Caveat
This raises the floor, not the ceiling. Modern webpack / Vite default behavior is to inline \`process.env.NEXT_PUBLIC_X\` as just the literal value at build time, dropping the key entirely. No regex can recover an env-var name that no longer appears in the bundle. This PR catches the cases where the developer kept the name in an object literal (the same case that already works for CRA today).

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] No regression on https://sourceacademy.org/ — same 13 env-var findings as before
- [ ] Optional: scan a Vite app that preserves \`VITE_*\` keys in an object literal to confirm the new prefix fires end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)