### PR TITLE
Recognize Astro's /_astro/ bundle path

### DIFF
--- a/cmd/kneejerk/main.go
+++ b/cmd/kneejerk/main.go
@@ -45,12 +45,13 @@ var jsFilePattern = regexp.MustCompile(`\.m?js(?:\?.*)?$`)
 
 // Path fragments that mark a JS bundle as belonging to the host application
 // rather than a third-party widget. Covers React/CRA, Next.js, Vite/Remix,
-// and SvelteKit out of the box.
+// SvelteKit, and Astro out of the box.
 var bundlePathPrefixes = []string{
 	"/static/",
 	"/_next/static/",
 	"/assets/",
 	"/_app/immutable/",
+	"/_astro/",
 }
 
 // Regex to find API path patterns of the form "METHOD", "/path"


### PR DESCRIPTION
## Summary
Add \`/_astro/\` to \`bundlePathPrefixes\`, completing the major-framework set: CRA + Next.js + Vite/Remix + SvelteKit + Astro.

## Why this, not Framer
Astro is a real meta-framework where developers write their own components and client-side "islands." Those islands can contain \`fetch('/api/...')\` and other custom code worth scanning. Framer's \`/sites/\` was deliberately skipped earlier because Framer is no-code and the bundles are mostly framework runtime — that reasoning doesn't apply to Astro.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] No regression on \`https://nextjs.org/\` — same four endpoints surface as before
- [ ] Optional: scan an Astro-built SaaS with client-side islands (rather than the static marketing site \`astro.build\`) to verify the new prefix surfaces findings end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)