### PR TITLE
Drop API endpoint matches that don't look like URLs

### DIFF
--- a/cmd/kneejerk/helpers.go
+++ b/cmd/kneejerk/helpers.go
@@ -11,6 +11,23 @@ import (
 
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+// Template-literal placeholders like ${encodeURIComponent(e)} are stripped
+// before the parens check in looksLikeURL so legitimate templated URLs
+// aren't mistaken for in-the-middle-of-an-expression false positives.
+var templatePlaceholder = regexp.MustCompile(`\$\{[^}]*\}`)
+
+// looksLikeURL filters out captured "endpoints" that are clearly not URLs —
+// most commonly regex misfires that grab a fragment of minified JS like
+// ".concat(JSON.stringify(e),". Real URL paths don't contain bare parens
+// once template-literal interpolations are stripped.
+func looksLikeURL(s string) bool {
+	if s == "" {
+		return false
+	}
+	stripped := templatePlaceholder.ReplaceAllString(s, "")
+	return !strings.ContainsAny(stripped, "()")
+}
+
 // Helper Functions
 func debugLog(debug bool, format string, v ...interface{}) {
 	if debug {

--- a/cmd/kneejerk/main.go
+++ b/cmd/kneejerk/main.go
@@ -94,6 +94,9 @@ func scrapeAPIPaths(jsURL string, jsContent string, debug bool) {
 	matches := apiPathPattern.FindAllStringSubmatch(jsContent, -1)
 	for _, match := range matches {
 		debugLog(debug, "Debug: Found API path match: %s\n", match)
+		if !looksLikeURL(match[2]) {
+			continue
+		}
 		if _, ok := foundVars[match[0]]; !ok {
 			foundVars[match[0]] = struct{}{}
 			printAPI(debug, jsURL, match[1], match[2])
@@ -146,6 +149,9 @@ func scrapeAPIPaths(jsURL string, jsContent string, debug bool) {
 			method := strings.ToUpper(match[2]) // Convert the method to uppercase
 			endpoint := strings.ReplaceAll(match[1], `${}`, "")
 			debugLog(debug, "Debug: Found AJAX endpoint: [%s, %s]\n", method, endpoint)
+			if !looksLikeURL(endpoint) {
+				continue
+			}
 			if _, ok := foundVars[endpoint]; !ok {
 				foundVars[endpoint] = struct{}{}
 				printAPI(debug, jsURL, method, endpoint)


### PR DESCRIPTION
## Summary
Filter out captured API "endpoints" that are clearly regex misfires — fragments of minified JS like \`.concat(JSON.stringify(e),\` that happen to slot into a method+path-shaped pattern.

## How it surfaced
While testing the recent coverage improvements on stripe.com, the scan produced this finding:
\`\`\`
["GET", ".concat(JSON.stringify(e),"]
\`\`\`
That's not a URL — it's a fragment of a minified \`String.prototype.concat\` call that the broadened \`apiPathPattern\` (commit 8353be0) accidentally matched.

## Fix
A new \`looksLikeURL\` helper is applied to every captured endpoint. It strips template-literal placeholders (\`\${...}\`) and rejects anything still containing bare parens. Real URL paths don't contain \`()\` once template interpolations are removed, but template interpolations like \`\${encodeURIComponent(e)}\` legitimately do — so we strip them before checking.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] Stripe: 3 → 2 findings (the \`.concat\` false positive dropped, real \`POST /-api/form\` and \`NODE_ENV\` retained)
- [x] Hashnode: 69 → 69 (no regression — all \`\${encodeURIComponent(e)}\`-style template-URL findings survive)
- [x] Source Academy: 15 → 15 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)